### PR TITLE
Add vertical zoom control

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ inspectrum is a tool for analysing captured signals, primarily from software-def
 ## Features
  * Large (100GB+) file support
  * Spectrogram with zoom/pan
+ * Vertical zoom for detailed frequency inspection
  * Plots of amplitude, frequency, phase and IQ samples
  * Cursors for measuring period, symbol rate and extracting symbols
  * Export of selected time period, filtered samples and demodulated data

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -46,6 +46,7 @@ MainWindow::MainWindow()
     connect(dock, &SpectrogramControls::openFile, this, &MainWindow::openFile);
     connect(dock->sampleRate, static_cast<void (QLineEdit::*)(const QString&)>(&QLineEdit::textChanged), this, static_cast<void (MainWindow::*)(QString)>(&MainWindow::setSampleRate));
     connect(dock, static_cast<void (SpectrogramControls::*)(int, int)>(&SpectrogramControls::fftOrZoomChanged), plots, &PlotView::setFFTAndZoom);
+    connect(dock, &SpectrogramControls::freqZoomChanged, plots, &PlotView::setFrequencyZoom);
     connect(dock->powerMaxSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMax);
     connect(dock->powerMinSlider, &QSlider::valueChanged, plots, &PlotView::setPowerMin);
     connect(dock->cursorsCheckBox, &QCheckBox::stateChanged, plots, &PlotView::enableCursors);

--- a/src/plotview.cpp
+++ b/src/plotview.cpp
@@ -455,6 +455,14 @@ void PlotView::setFFTAndZoom(int size, int zoom)
     updateView(true, samplesPerColumn() < oldSamplesPerColumn);
 }
 
+void PlotView::setFrequencyZoom(int zoom)
+{
+    freqZoomLevel = zoom;
+    if (spectrogramPlot != nullptr)
+        spectrogramPlot->setFrequencyZoom(zoom);
+    updateView();
+}
+
 void PlotView::setPowerMin(int power)
 {
     powerMin = power;

--- a/src/plotview.h
+++ b/src/plotview.h
@@ -52,6 +52,7 @@ public slots:
     void repaint();
     void setCursorSegments(int segments);
     void setFFTAndZoom(int fftSize, int zoomLevel);
+    void setFrequencyZoom(int zoomLevel);
     void setPowerMin(int power);
     void setPowerMax(int power);
 
@@ -77,6 +78,7 @@ private:
 
     int fftSize = 1024;
     int zoomLevel = 1;
+    int freqZoomLevel = 1;
     int powerMin;
     int powerMax;
     bool cursorsEnabled;

--- a/src/spectrogramcontrols.cpp
+++ b/src/spectrogramcontrols.cpp
@@ -57,6 +57,12 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     layout->addRow(new QLabel(tr("Zoom:")), zoomLevelSlider);
 
+    freqZoomLevelSlider = new QSlider(Qt::Horizontal, widget);
+    freqZoomLevelSlider->setRange(0, 4);
+    freqZoomLevelSlider->setPageStep(1);
+
+    layout->addRow(new QLabel(tr("Freq Zoom:")), freqZoomLevelSlider);
+
     powerMaxSlider = new QSlider(Qt::Horizontal, widget);
     powerMaxSlider->setRange(-140, 10);
     layout->addRow(new QLabel(tr("Power max:")), powerMaxSlider);
@@ -107,6 +113,7 @@ SpectrogramControls::SpectrogramControls(const QString & title, QWidget * parent
 
     connect(fftSizeSlider, &QSlider::valueChanged, this, &SpectrogramControls::fftSizeChanged);
     connect(zoomLevelSlider, &QSlider::valueChanged, this, &SpectrogramControls::zoomLevelChanged);
+    connect(freqZoomLevelSlider, &QSlider::valueChanged, this, &SpectrogramControls::freqZoomLevelChanged);
     connect(fileOpenButton, &QPushButton::clicked, this, &SpectrogramControls::fileOpenButtonClicked);
     connect(cursorsCheckBox, &QCheckBox::stateChanged, this, &SpectrogramControls::cursorsStateChanged);
     connect(powerMinSlider, &QSlider::valueChanged, this, &SpectrogramControls::powerMinChanged);
@@ -146,6 +153,7 @@ void SpectrogramControls::setDefaults()
     powerMaxSlider->setValue(settings.value("PowerMax", 0).toInt());
     powerMinSlider->setValue(settings.value("PowerMin", -100).toInt());
     zoomLevelSlider->setValue(settings.value("ZoomLevel", 0).toInt());
+    freqZoomLevelSlider->setValue(settings.value("FreqZoomLevel", 0).toInt());
 }
 
 void SpectrogramControls::fftOrZoomChanged(void)
@@ -167,6 +175,13 @@ void SpectrogramControls::zoomLevelChanged(int value)
     QSettings settings;
     settings.setValue("ZoomLevel", value);
     fftOrZoomChanged();
+}
+
+void SpectrogramControls::freqZoomLevelChanged(int value)
+{
+    QSettings settings;
+    settings.setValue("FreqZoomLevel", value);
+    emit freqZoomChanged((int)pow(2, value));
 }
 
 void SpectrogramControls::powerMinChanged(int value)

--- a/src/spectrogramcontrols.h
+++ b/src/spectrogramcontrols.h
@@ -38,6 +38,7 @@ public:
 
 signals:
     void fftOrZoomChanged(int fftSize, int zoomLevel);
+    void freqZoomChanged(int zoomLevel);
     void openFile(QString fileName);
 
 public slots:
@@ -49,6 +50,7 @@ public slots:
 private slots:
     void fftSizeChanged(int value);
     void zoomLevelChanged(int value);
+    void freqZoomLevelChanged(int value);
     void powerMinChanged(int value);
     void powerMaxChanged(int value);
     void fileOpenButtonClicked();
@@ -65,6 +67,7 @@ public:
     QLineEdit *sampleRate;
     QSlider *fftSizeSlider;
     QSlider *zoomLevelSlider;
+    QSlider *freqZoomLevelSlider;
     QSlider *powerMaxSlider;
     QSlider *powerMinSlider;
     QCheckBox *cursorsCheckBox;

--- a/src/spectrogramplot.cpp
+++ b/src/spectrogramplot.cpp
@@ -37,6 +37,7 @@ SpectrogramPlot::SpectrogramPlot(std::shared_ptr<SampleSource<std::complex<float
 {
     setFFTSize(fftSize);
     zoomLevel = 1;
+    freqZoomLevel = 1;
     powerMax = 0.0f;
     powerMin = -50.0f;
     sampleRate = 0;
@@ -375,11 +376,8 @@ void SpectrogramPlot::setFFTSize(int size)
         window[i] = 0.5f * (1.0f - cos(Tau * i / (fftSize - 1)));
     }
 
-    if (inputSource->realSignal()) {
-        setHeight(fftSize/2);
-    } else {
-        setHeight(fftSize);
-    }
+    int baseHeight = inputSource->realSignal() ? fftSize/2 : fftSize;
+    setHeight(baseHeight * freqZoomLevel);
     auto dev = tuner.deviation();
     auto centre = tuner.centre();
     tuner.setHeight(height());
@@ -403,6 +401,15 @@ void SpectrogramPlot::setPowerMin(int power)
 void SpectrogramPlot::setZoomLevel(int zoom)
 {
     zoomLevel = zoom;
+}
+
+void SpectrogramPlot::setFrequencyZoom(int zoom)
+{
+    freqZoomLevel = zoom;
+    int baseHeight = inputSource->realSignal() ? fftSize/2 : fftSize;
+    setHeight(baseHeight * freqZoomLevel);
+    tuner.setHeight(height());
+    tunerMoved();
 }
 
 void SpectrogramPlot::setSampleRate(double rate)

--- a/src/spectrogramplot.h
+++ b/src/spectrogramplot.h
@@ -60,6 +60,7 @@ public slots:
     void setPowerMax(int power);
     void setPowerMin(int power);
     void setZoomLevel(int zoom);
+    void setFrequencyZoom(int zoom);
     void tunerMoved();
 
 private:
@@ -76,6 +77,7 @@ private:
 
     int fftSize;
     int zoomLevel;
+    int freqZoomLevel;
     float powerMax;
     float powerMin;
     double sampleRate;


### PR DESCRIPTION
## Summary
- add vertical zoom feature for spectrogram
- wire new frequency zoom slider through UI and plot handling
- document new feature in README

## Testing
- `cmake ..` *(fails: Qt not installed)*